### PR TITLE
Have `decode() accept '&str' instead of '&String'.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub fn encode(bytes: &[u8]) -> String {
     encoded_data.iter().map(|c| CHARMAP[*c as usize] as char).collect()
 }
 
-pub fn decode(string: &String) -> Vec<u8> {
+pub fn decode(string: &str) -> Vec<u8> {
     let mut decoded_data: Vec<u8> = Vec::new();
     let bytes = string.as_bytes();
     for chunk in bytes.chunks(4) {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -21,8 +21,8 @@ fn it_works() {
 
     for pair in pairs.clone() {
         println!("Decode {:?}", pair);
-        let decoded_data = base64::decode(&pair.1.to_string());
+        let decoded_data = base64::decode(&pair.1);
         let decoded_string: String = decoded_data.iter().map(|c| *c as char).collect();
-        assert_eq!(decoded_string, pair.0.to_string());
+        assert_eq!(decoded_string, pair.0);
     }
 }


### PR DESCRIPTION
This allows some callers, including the tests, to avoid constructing a
'String' to decode when they only have a '&str'.